### PR TITLE
using mongodb indexing for getting the wallet for a particular encryp…

### DIFF
--- a/src/controllers/wallet.ts
+++ b/src/controllers/wallet.ts
@@ -194,13 +194,13 @@ export class WalletController {
   }
  }
 
- static async getWallet(req: express.Request & { privateKey: string; }, res: express.Response): Promise<any> {
+ static async getWallet(req: express.Request & { privateKey: string, publicKey: string;}, res: express.Response): Promise<any> {
   try {
    // Private key would be deserialized from a token and passed into the request object
    const privateKey: string = req.privateKey;
-
+			const publicKey: string = req.publicKey;
    // Get wallet using private key
-   const wallet = await DBWallet.getWallet(privateKey);
+   const wallet = await DBWallet.getWallet(privateKey,publicKey);
 
    // Send response
    res.status(200).json({

--- a/src/db/models/wallet.ts
+++ b/src/db/models/wallet.ts
@@ -29,13 +29,13 @@ export class WalletModel {
   return Promise.resolve(decryptedWallet);
  }
 
- async getWallet(privateKey: string): Promise<Wallet> {
-  const encryptedWallets = await this.model.find();
-  let encryptedWallet = null;
-  encryptedWallets.forEach((encWallet: mongoose.Document & { encryptedPrivateKey: string, encryptedWallet: string }) => {
-   if (Tokenizers.decryptPrivateKey(encWallet.encryptedPrivateKey) === privateKey)
-    encryptedWallet = encWallet.encryptedWallet;
-  });
+ async getWallet(privateKey: string, publicKey: string): Promise<Wallet> {
+  const encPrivateKey: string = Tokenizers.encryptPrivateKey(privateKey, publicKey)
+  // Below find utilizes the indexing created on encryptedPrivateKey field
+  // and is way faster than linear search on whole collection
+  const encWallet: mongoose.Document & { encryptedPrivateKey: string; encryptedWallet: string } 
+   = await this.model.findOne({encryptedPrivateKey: encPrivateKey});
+  const encryptedWallet: string = encWallet.encryptedWallet;
   const decryptedWallet: Wallet = Tokenizers.decryptWallet(encryptedWallet, privateKey);
   return Promise.resolve(decryptedWallet);
  }

--- a/src/middlewares/wallet.ts
+++ b/src/middlewares/wallet.ts
@@ -52,13 +52,13 @@ export class WalletMiddleware {
  }
 
  static async getWalletFromRequest(
-  req: express.Request & { privateKey: string; wallet: Wallet },
+  req: express.Request & { privateKey: string; publicKey: string; wallet: Wallet },
   res: express.Response,
   next: express.NextFunction
  ) {
   try {
    // Get wallet from privateKey
-   const wallet = await DBWallet.getWallet(req.privateKey);
+   const wallet = await DBWallet.getWallet(req.privateKey,req.publicKey);
 
    // Check if wallet is null
    if (!wallet)
@@ -97,7 +97,7 @@ export class WalletMiddleware {
    const keyPair = await Tokenizers.generateKeyPairs(phrase);
 
    // Get wallet using private key
-   const wallet: Wallet = await DBWallet.getWallet(keyPair.privateKey);
+   const wallet: Wallet = await DBWallet.getWallet(keyPair.privateKey, keyPair.publicKey);
 
    // Respond with a 404 if wallet is not found
    if (!wallet)


### PR DESCRIPTION
Changes Summary : 
Using mongodb indexing for getting the wallet for a particular encrypted private key.
This will be a lot faster than the full table scan.

I have created the index in mongoDB on "encryptedPrivateKey" field.