### PR TITLE
fix for recoverWallet api and including coinFullName

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "tronweb": "^3.0.0",
     "tslib": "^2.0.2",
     "typescript": "^3.9.7",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "elliptic": "^6.5.3"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",

--- a/src/core/utils/tokenizer.ts
+++ b/src/core/utils/tokenizer.ts
@@ -3,17 +3,22 @@ import jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
 import { Wallet } from "../interfaces";
 import { Environment } from "../../env";
+const EC = require('elliptic').ec;
+const ec = new EC('secp256k1');
 // import { TransactionStatus } from "../enums";
 
 export class Tokenizers {
  static hash(input: string): string {
   return hasher.SHA256(input).toString();
  }
-
+ static getPublicKey(k: string): string {
+		return ec.keyFromPrivate(k).getPublic().encode("hex");
+	}
  static async generateKeyPairs(recoveryPhrase: string): Promise<{ publicKey: string; privateKey: string }> {
-  return Promise.resolve({
-   publicKey: Tokenizers.hash(uuid()),
-   privateKey: Tokenizers.hash(recoveryPhrase)
+		const pk = Tokenizers.hash(recoveryPhrase);
+		return Promise.resolve({
+			privateKey: pk,
+			publicKey: this.getPublicKey(pk),
   });
  }
 

--- a/src/core/utils/wallet_adaptor.ts
+++ b/src/core/utils/wallet_adaptor.ts
@@ -1,11 +1,11 @@
 import { Wallet } from "../interfaces";
-import { COINS_IMAGE_URLS, CURRENT_COINS } from "../handlers/commons";
+import { COINS_IMAGE_URLS, CURRENT_COINS, COINS_MAP } from "../handlers/commons";
 
 export class WalletAdaptor {
  static async convert(wallet: Wallet) : Promise<any> {
 		const coinList: Array<any> = [];
 		for (const coin of CURRENT_COINS) {
-			coinList.push({name: coin, ...wallet[coin], image: COINS_IMAGE_URLS.get(coin)})
+			coinList.push({name: coin, coinFullName: COINS_MAP.get(coin)["name"], ...wallet[coin], image: COINS_IMAGE_URLS.get(coin)})
 		}
   return {
 			privateKey: wallet.privateKey,


### PR DESCRIPTION
Change Summary : 
1. Fixed recoverWallet API , generate publickey from the private key using secp256k1 ECC curve.
2. Added coinFullName in wallets responses for UI. 